### PR TITLE
Add missing memory frees

### DIFF
--- a/driver/poisson_mms.f90
+++ b/driver/poisson_mms.f90
@@ -24,6 +24,7 @@ program poissonMMS
   integer :: ib,iter,ngrids,irefine,nref,ndof,ntypes,nv2,i,jmax,jmax2
   integer :: mexclude,nfringe
   integer :: mdim(3)
+  integer :: iargc
   !
   logical :: testSolver,saveout
   !

--- a/src/exchangeAMRDonors.C
+++ b/src/exchangeAMRDonors.C
@@ -290,10 +290,6 @@ void tioga::exchangeAMRDonors(void)
   TIOGA_FREE(obreceptors);
   TIOGA_FREE(imap);
   TIOGA_FREE(icount);
-  for(i=0;i<nsend;i++) {
-      TIOGA_FREE(sndPack[i].intData);
-      TIOGA_FREE(sndPack[i].realData);
-  }
   TIOGA_FREE(sndPack);
   TIOGA_FREE(rcvPack);
 }

--- a/src/exchangeAMRDonors.C
+++ b/src/exchangeAMRDonors.C
@@ -286,8 +286,14 @@ void tioga::exchangeAMRDonors(void)
   TIOGA_FREE(intcount);
   TIOGA_FREE(sndMapAll);
   TIOGA_FREE(rcvMapAll);
+  TIOGA_FREE(obdonors);
+  TIOGA_FREE(obreceptors);
   TIOGA_FREE(imap);
   TIOGA_FREE(icount);
+  for(i=0;i<nsend;i++) {
+      TIOGA_FREE(sndPack[i].intData);
+      TIOGA_FREE(sndPack[i].realData);
+  }
   TIOGA_FREE(sndPack);
   TIOGA_FREE(rcvPack);
 }

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -391,12 +391,8 @@ void tioga::dataUpdate_AMR()
   //
   //this->writeData(nvar,0);
   pc_cart->clearPackets2(sndPack,rcvPack);
-  TIOGA_FREE(rcvPack);
-  for(k=0;k<nsend;k++) {
-     TIOGA_FREE(sndPack[k].intData);
-     TIOGA_FREE(sndPack[k].realData);
-  }
   TIOGA_FREE(sndPack);
+  TIOGA_FREE(rcvPack);
 
   if (integerRecords) TIOGA_FREE(integerRecords);
   if (realRecords) TIOGA_FREE(realRecords);

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -393,7 +393,6 @@ void tioga::dataUpdate_AMR()
   pc_cart->clearPackets2(sndPack,rcvPack);
   TIOGA_FREE(sndPack);
   TIOGA_FREE(rcvPack);
-
   if (integerRecords) TIOGA_FREE(integerRecords);
   if (realRecords) TIOGA_FREE(realRecords);
   if (icount) TIOGA_FREE(icount);

--- a/src/tioga.C
+++ b/src/tioga.C
@@ -391,8 +391,13 @@ void tioga::dataUpdate_AMR()
   //
   //this->writeData(nvar,0);
   pc_cart->clearPackets2(sndPack,rcvPack);
-  TIOGA_FREE(sndPack);
   TIOGA_FREE(rcvPack);
+  for(k=0;k<nsend;k++) {
+     TIOGA_FREE(sndPack[k].intData);
+     TIOGA_FREE(sndPack[k].realData);
+  }
+  TIOGA_FREE(sndPack);
+
   if (integerRecords) TIOGA_FREE(integerRecords);
   if (realRecords) TIOGA_FREE(realRecords);
   if (icount) TIOGA_FREE(icount);


### PR DESCRIPTION
The fortran change allows us to not to have to patch tioga as well. It makes `iargc` explicit.